### PR TITLE
update output to clean up test runs

### DIFF
--- a/cmd/testdrive/run_test.go
+++ b/cmd/testdrive/run_test.go
@@ -72,10 +72,10 @@ func TestRunCommandExecuteFailure(t *testing.T) {
 	}
 
 	output := out.String()
-	if !strings.Contains(output, "✓ Hello Step") {
+	if !strings.Contains(output, "✅ Hello Step") {
 		t.Fatalf("expected success marker for first step, got %q", output)
 	}
-	if !strings.Contains(output, "✗ Failing Step") {
+	if !strings.Contains(output, "❌ Failing Step") {
 		t.Fatalf("expected failure marker, got %q", output)
 	}
 	if !strings.Contains(output, "SUMMARY: 1 passed, 1 failed, 0 skipped") {

--- a/internal/output/pretty.go
+++ b/internal/output/pretty.go
@@ -198,10 +198,7 @@ func (s *StreamingPrettyRenderer) InitializeAllJobs(workflows []provider.Workflo
 				lineNumber: s.totalLinesPrinted, // Track which line this job is on
 			}
 			
-			// Set initial status (first job starts running, others pending)
-            // First job is running; others pending. Do NOT call StartJob again for the
-            // first job or we will double-print. We only change state here, the line
-            // is already printed below.
+            // Set first job to "running" and others to "pending"; first job's line is already printed.
             if s.totalLinesPrinted == 0 {
                 jobInfo.status = "running"
                 jobInfo.startTime = time.Now()
@@ -214,7 +211,7 @@ func (s *StreamingPrettyRenderer) InitializeAllJobs(workflows []provider.Workflo
                 fmt.Fprintf(s.out, "⏳ %s\n", job.Name)
             }
             // We just printed exactly one line for this job
-            s.totalLinesPrinted = s.totalLinesPrinted + 1
+            s.totalLinesPrinted++
 			
 			workflow.jobs = append(workflow.jobs, jobInfo)
 		}
@@ -316,11 +313,8 @@ func (s *StreamingPrettyRenderer) CompleteJob() error {
 	return nil
 }
 
-func isTerminal() bool {
-	// Simple check - always return true for now
-	// The issue might be elsewhere
-	return true
-}
+// isTerminal is a placeholder; in production we may gate ANSI behavior on TTY.
+func isTerminal() bool { return true }
 
 // updateJobLineInPlace updates a single job line in place
 func (s *StreamingPrettyRenderer) updateJobLineInPlace(_ *jobInfo) {

--- a/internal/output/pretty.go
+++ b/internal/output/pretty.go
@@ -349,41 +349,6 @@ func (s *StreamingPrettyRenderer) updateJobLineInPlace() {
     // Cursor naturally ends one line below the block after printing \n each row
 }
 
-// overwriteJobLine rewrites one job line in-place with the given emoji and optional duration
-func (s *StreamingPrettyRenderer) overwriteJobLine(job *jobInfo, emoji string, withDuration bool) {
-    // Determine emoji based on job status if not provided
-    if emoji == "" {
-        switch job.status {
-        case "passed":
-            emoji = "✅"
-        case "failed":
-            emoji = "❌"
-        case "running":
-            emoji = "🟢"
-        case "pending":
-            emoji = "⏳"
-        case "skipped":
-            emoji = "⏭️"
-        default:
-            emoji = "❓"
-        }
-    }
-    
-    linesUp := s.totalLinesPrinted - job.lineNumber - 1
-    for j := 0; j < linesUp; j++ {
-        fmt.Fprintf(s.out, "\033[1A")
-    }
-    fmt.Fprintf(s.out, "\033[2K\r")
-    if withDuration {
-        fmt.Fprintf(s.out, "%s %s (%s)\n", emoji, job.name, formatDuration(job.duration))
-    } else {
-        fmt.Fprintf(s.out, "%s %s\n", emoji, job.name)
-    }
-    for j := 0; j < linesUp; j++ {
-        fmt.Fprintf(s.out, "\033[1B")
-    }
-}
-
 // updateJobLine updates the job status line in place
 func (s *StreamingPrettyRenderer) updateJobLine(job *jobInfo) {
 	var emoji string

--- a/internal/output/pretty.go
+++ b/internal/output/pretty.go
@@ -313,8 +313,6 @@ func (s *StreamingPrettyRenderer) CompleteJob() error {
 	return nil
 }
 
-// isTerminal is a placeholder; in production we may gate ANSI behavior on TTY.
-func isTerminal() bool { return true }
 
 // updateJobLineInPlace redraws all job lines in place
 func (s *StreamingPrettyRenderer) updateJobLineInPlace() {

--- a/internal/output/pretty.go
+++ b/internal/output/pretty.go
@@ -316,8 +316,8 @@ func (s *StreamingPrettyRenderer) CompleteJob() error {
 // isTerminal is a placeholder; in production we may gate ANSI behavior on TTY.
 func isTerminal() bool { return true }
 
-// updateJobLineInPlace updates a single job line in place
-func (s *StreamingPrettyRenderer) updateJobLineInPlace(_ *jobInfo) {
+// updateJobLineInPlace redraws all job lines in place
+func (s *StreamingPrettyRenderer) updateJobLineInPlace() {
     // Redraw the entire block deterministically.
     // 1) Move cursor up by number of jobs
     totalJobs := 0


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the streaming pretty renderer for job and step output. The main focus is on making job status updates more reliable and visually consistent by improving in-place updates and tracking output lines, as well as refining the use of status emojis. It also disables the timer-based live update mechanism to prevent duplicate lines, moving toward a more deterministic rendering approach.

Key changes include:

**Job Output Rendering and State Tracking:**
- Added fields to `StreamingPrettyRenderer` and `jobInfo` to track the current output line and whether detailed failure info has been shown, enabling accurate in-place updates and preventing duplicate or misplaced output. (`internal/output/pretty.go`) [[1]](diffhunk://#diff-a915f8ee09f4e978a46506d00ea0e5797feca1f2912ade69704694de4d6036ceR44-R47) [[2]](diffhunk://#diff-a915f8ee09f4e978a46506d00ea0e5797feca1f2912ade69704694de4d6036ceR62)
- Jobs are now initialized and displayed with a clear distinction between the first running job and pending jobs, with precise line tracking for each job. (`internal/output/pretty.go`) [[1]](diffhunk://#diff-a915f8ee09f4e978a46506d00ea0e5797feca1f2912ade69704694de4d6036ceL164-R174) [[2]](diffhunk://#diff-a915f8ee09f4e978a46506d00ea0e5797feca1f2912ade69704694de4d6036ceL187-R239)

**In-Place Job Line Updates:**
- Introduced `updateJobLineInPlace` to redraw all job lines deterministically, ensuring that status changes (e.g., running, passed, failed) are reflected immediately and cleanly in the terminal without duplicating lines. (`internal/output/pretty.go`)
- Modified job completion logic to use the new in-place update and only show detailed failure info once per job. (`internal/output/pretty.go`) [[1]](diffhunk://#diff-a915f8ee09f4e978a46506d00ea0e5797feca1f2912ade69704694de4d6036ceL275-L283) [[2]](diffhunk://#diff-a915f8ee09f4e978a46506d00ea0e5797feca1f2912ade69704694de4d6036ceR497-R501)

**Step and Error Output Improvements:**
- Step details for failed jobs now increment the total line count, ensuring accurate cursor positioning for subsequent output. (`internal/output/pretty.go`) [[1]](diffhunk://#diff-a915f8ee09f4e978a46506d00ea0e5797feca1f2912ade69704694de4d6036ceR416) [[2]](diffhunk://#diff-a915f8ee09f4e978a46506d00ea0e5797feca1f2912ade69704694de4d6036ceR430-R467)

**Timer and Live Updates:**
- Disabled the background timer for live elapsed time updates to prevent duplicate or out-of-order lines, with a note to revisit this functionality. (`internal/output/pretty.go`)

**Status Emoji Consistency:**
- Updated test assertions and output to use consistent Unicode emojis for pass/fail markers. (`cmd/testdrive/run_test.go`)

These changes collectively make the output more robust, visually clear, and maintainable, especially when jobs change status or fail.